### PR TITLE
Configure the translations on initialization

### DIFF
--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -1,12 +1,12 @@
 require "date"
 require "ice_cube/deprecated"
+require "ice_cube/i18n"
 
 module IceCube
   autoload :VERSION, "ice_cube/version"
 
   autoload :TimeUtil, "ice_cube/time_util"
   autoload :FlexibleHash, "ice_cube/flexible_hash"
-  autoload :I18n, "ice_cube/i18n"
 
   autoload :Rule, "ice_cube/rule"
   autoload :Schedule, "ice_cube/schedule"

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -17,10 +17,12 @@ module IceCube
     end
 
     def self.detect_backend!
-      ::I18n.load_path += Dir[File.join(LOCALES_PATH, "*.yml")]
       ::I18n
     rescue NameError
       NullI18n
     end
   end
 end
+
+# Load the translations early in order not to override the user’s translations.
+::I18n.load_path += Dir[File.join(IceCube::I18n::LOCALES_PATH, "*.yml")] if defined? I18n


### PR DESCRIPTION
ice_cube’s translations must be loaded before the user application’s translations. Otherwise, ice_cube erases the user’s customization whenever it is called, which may happen any time after the application started.